### PR TITLE
fix: Add HTTP/2 support

### DIFF
--- a/libs/http.go
+++ b/libs/http.go
@@ -38,6 +38,7 @@ type Request struct {
 	Port              string
 	Path              string
 	URL               string
+	Proto             string
 	Proxy             string
 	Method            string
 	Payload           string


### PR DESCRIPTION
Adding HTTP/2 support. The way that jaeles used to parse the requests was changed because the net/http lib doesn't support HTTP/2 requests.

References: https://pkg.go.dev/net/http#ReadRequest

It was also added a new attribute to the Request structure called "Proto", which will provide the version of the HTTP protocol being used: e.g. "HTTP/2 or HTTP/1.1"