### PR TITLE
Changed golang:1.14-buster to golang:1.16-buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-buster as builder
+FROM golang:1.16-buster as builder
 RUN GO111MODULE=on GOOS=linux go get -ldflags "-linkmode external -extldflags -static" github.com/jaeles-project/jaeles
 
 FROM alpine:latest


### PR DESCRIPTION
Fixes the below error:
```#0 6.877 pkg/mod/github.com/chromedp/chromedp@v0.8.2/js.go:4:2: package embed is not in GOROOT (/usr/local/go/src/embed)
------
Dockerfile:2
--------------------
   1 |     FROM golang:1.14-buster as builder
   2 | >>> RUN GO111MODULE=on GOOS=linux go get -ldflags "-linkmode external -extldflags -static" github.com/jaeles-project/jaeles
   3 |     RUN GO111MODULE=on GOOS=linux go get -ldflags "-linkmode external -extldflags -static" github.com/mafredri/cdp
   4 |     FROM alpine:latest
--------------------
ERROR: failed to solve: process "/bin/sh -c GO111MODULE=on GOOS=linux go get -ldflags \"-linkmode external -extldflags -static\" github.com/jaeles-project/jaeles" did not complete successfully: exit code: 1```